### PR TITLE
update chart to include service and ingress annotations functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,32 +34,32 @@ This chart requires that `existingSecrets` are created separately to this chart 
 In the case of **mongodb** this helps prevent you from a situation that arises when you allow mongodb to auto-generate it's secret. In this scenario, if you ever need to re-release the mongodb chart, whilst keeping the existing `PersistentVolumeClaim` (underlying data), The mongodb `Deployment` will use a newly generated secrets, but the data volume will continue using the previously generated secrets. You essentially get locked out of your own data if you're not careful.
 
 
-| Value name                      | Description                                                            | Default                    |
-| ------------------------------- | ---------------------------------------------------------------------- | -------------------------- |
-| dashboard.replicaCount          | Number of dashboard pods                                               | `1`                        |
-| dashboard.image.repository      | Dashboard image repository                                             | `sprints-dashboard`        |
-| dashboard.image.pullPolicy      | Dashboard image pullPolicy                                             | `IfNotPresent`             |
-| dashboard.image.tag             | Dashboard image tag                                                    | `local`                    |
-| dashboard.imagePullSecrets      | Dashboard image pull secrets                                           | `[]`                       |
-| dashboard.podSecurityContext    | Dashboard pod security context                                         | `{}`                       |
-| dashboard.SecurityContext       | Dashboard container security context                                   | `{}`                       |
-| dashboard.service.type          | Dashboard service type                                                 | `ClusterIP`                |
-| dashboard.service.annotations   | Dashboard service annotations                                          |                            |
-| dashboard.service.port          | Port that the dashboard service is reachable on                        | `80`                       |
-| dashboard.service.targetPort    | Port that the dashboard container exposes                              | `8000`                     |
-| dashboard.ingress.enabled       | Whether to enable an ingress resource or not                           | `false`                    |
-| dashboard.ingress.hosts         | if enabled, the default hosts                                          | path `/` on `localhost`    |
-| dashboard.ingress.tls           | if enabled, the default tls config                                     | `[]`                       |
-| dashboard.resources             | Dashboard resource requests and limits                                 | `{}`                       |
-| dashboard.nodeSelector          | Dashboard node selector                                                | `{}`                       |
-| dashboard.tolerations           | Dashboard taint tolerations                                            | `[]`                       |
-| dashboard.affinity              | Dashboard pod affinity                                                 | `{}`                       |
-| jira.config                     | Jira config file as described [here](#jira-config)                     | `{}`                       |
-| jira.credentials.existingSecret | An existing jira secret containing credentials ***required**           | `{}`                       |
-| dataCollection.enabled          | Whether to deploy the data collection `Cronjobs` or not                | `false`                    |
-| dataCollection.image.repository | Dashboard image repository                                             | `sprints-dashboard`        |
-| dataCollection.image.pullPolicy | Dashboard image pullPolicy                                             | `IfNotPresent`             |
-| dataCollection.image.tag        | Dashboard image tag                                                    | `local`                    |
+| Value name                      | Description                                                  | Default                                                      |
+| ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| dashboard.replicaCount          | Number of dashboard pods                                     | `1`                                                          |
+| dashboard.image.repository      | Dashboard image repository                                   | `sprints-dashboard`                                          |
+| dashboard.image.pullPolicy      | Dashboard image pullPolicy                                   | `IfNotPresent`                                               |
+| dashboard.image.tag             | Dashboard image tag                                          | `local`                                                      |
+| dashboard.imagePullSecrets      | Dashboard image pull secrets                                 | `[]`                                                         |
+| dashboard.podSecurityContext    | Dashboard pod security context                               | `{}`                                                         |
+| dashboard.SecurityContext       | Dashboard container security context                         | `{}`                                                         |
+| dashboard.service.type          | Dashboard service type                                       | `ClusterIP`                                                  |
+| dashboard.service.annotations   | Dashboard service annotations                                | `service.beta.kubernetes.io/aws-load-balancer-type: externa`l<br />`service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip`<br />`service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing` |
+| dashboard.service.port          | Port that the dashboard service is reachable on              | `80`                                                         |
+| dashboard.service.targetPort    | Port that the dashboard container exposes                    | `8000`                                                       |
+| dashboard.ingress.enabled       | Whether to enable an ingress resource or not                 | `false`                                                      |
+| dashboard.ingress.hosts         | if enabled, the default hosts                                | path `/` on `localhost`                                      |
+| dashboard.ingress.tls           | if enabled, the default tls config                           | `[]`                                                         |
+| dashboard.resources             | Dashboard resource requests and limits                       | `{}`                                                         |
+| dashboard.nodeSelector          | Dashboard node selector                                      | `{}`                                                         |
+| dashboard.tolerations           | Dashboard taint tolerations                                  | `[]`                                                         |
+| dashboard.affinity              | Dashboard pod affinity                                       | `{}`                                                         |
+| jira.config                     | Jira config file as described [here](#jira-config)           | `{}`                                                         |
+| jira.credentials.existingSecret | An existing jira secret containing credentials ***required** | `{}`                                                         |
+| dataCollection.enabled          | Whether to deploy the data collection `Cronjobs` or not      | `false`                                                      |
+| dataCollection.image.repository | Dashboard image repository                                   | `sprints-dashboard`                                          |
+| dataCollection.image.pullPolicy | Dashboard image pullPolicy                                   | `IfNotPresent`                                               |
+| dataCollection.image.tag        | Dashboard image tag                                          | `local`                                                      |
 
 ## MongoDB Values
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ In the case of **mongodb** this helps prevent you from a situation that arises w
 | dashboard.podSecurityContext    | Dashboard pod security context                               | `{}`                    |
 | dashboard.SecurityContext       | Dashboard container security context                         | `{}`                    |
 | dashboard.service.type          | Dashboard service type                                       | `ClusterIP`             |
-| dashboard.service.annotations   | Dashboard service annotations                                |                         |
+| dashboard.service.annotations   | Dashboard service annotations                                | `[]`                    |
 | dashboard.service.port          | Port that the dashboard service is reachable on              | `80`                    |
 | dashboard.service.targetPort    | Port that the dashboard container exposes                    | `8000`                  |
 | dashboard.ingress.enabled       | Whether to enable an ingress resource or not                 | `false`                 |
 | dashboard.ingress.hosts         | if enabled, the default hosts                                | path `/` on `localhost` |
+| dashboard.ingress.annotations   | Dashboard ingress annotations                                | `[]`                    |
 | dashboard.ingress.tls           | if enabled, the default tls config                           | `[]`                    |
 | dashboard.resources             | Dashboard resource requests and limits                       | `{}`                    |
 | dashboard.nodeSelector          | Dashboard node selector                                      | `{}`                    |

--- a/README.md
+++ b/README.md
@@ -34,32 +34,32 @@ This chart requires that `existingSecrets` are created separately to this chart 
 In the case of **mongodb** this helps prevent you from a situation that arises when you allow mongodb to auto-generate it's secret. In this scenario, if you ever need to re-release the mongodb chart, whilst keeping the existing `PersistentVolumeClaim` (underlying data), The mongodb `Deployment` will use a newly generated secrets, but the data volume will continue using the previously generated secrets. You essentially get locked out of your own data if you're not careful.
 
 
-| Value name                      | Description                                                  | Default                                                      |
-| ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| dashboard.replicaCount          | Number of dashboard pods                                     | `1`                                                          |
-| dashboard.image.repository      | Dashboard image repository                                   | `sprints-dashboard`                                          |
-| dashboard.image.pullPolicy      | Dashboard image pullPolicy                                   | `IfNotPresent`                                               |
-| dashboard.image.tag             | Dashboard image tag                                          | `local`                                                      |
-| dashboard.imagePullSecrets      | Dashboard image pull secrets                                 | `[]`                                                         |
-| dashboard.podSecurityContext    | Dashboard pod security context                               | `{}`                                                         |
-| dashboard.SecurityContext       | Dashboard container security context                         | `{}`                                                         |
-| dashboard.service.type          | Dashboard service type                                       | `ClusterIP`                                                  |
-| dashboard.service.annotations   | Dashboard service annotations                                | `service.beta.kubernetes.io/aws-load-balancer-type: externa`l<br />`service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip`<br />`service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing`<br />`external-dns.alpha.kubernetes.io/hostname: agile-insights-proxy-oauth2-proxy` |
-| dashboard.service.port          | Port that the dashboard service is reachable on              | `80`                                                         |
-| dashboard.service.targetPort    | Port that the dashboard container exposes                    | `8000`                                                       |
-| dashboard.ingress.enabled       | Whether to enable an ingress resource or not                 | `false`                                                      |
-| dashboard.ingress.hosts         | if enabled, the default hosts                                | path `/` on `localhost`                                      |
-| dashboard.ingress.tls           | if enabled, the default tls config                           | `[]`                                                         |
-| dashboard.resources             | Dashboard resource requests and limits                       | `{}`                                                         |
-| dashboard.nodeSelector          | Dashboard node selector                                      | `{}`                                                         |
-| dashboard.tolerations           | Dashboard taint tolerations                                  | `[]`                                                         |
-| dashboard.affinity              | Dashboard pod affinity                                       | `{}`                                                         |
-| jira.config                     | Jira config file as described [here](#jira-config)           | `{}`                                                         |
-| jira.credentials.existingSecret | An existing jira secret containing credentials ***required** | `{}`                                                         |
-| dataCollection.enabled          | Whether to deploy the data collection `Cronjobs` or not      | `false`                                                      |
-| dataCollection.image.repository | Dashboard image repository                                   | `sprints-dashboard`                                          |
-| dataCollection.image.pullPolicy | Dashboard image pullPolicy                                   | `IfNotPresent`                                               |
-| dataCollection.image.tag        | Dashboard image tag                                          | `local`                                                      |
+| Value name                      | Description                                                  | Default                 |
+| ------------------------------- | ------------------------------------------------------------ | ----------------------- |
+| dashboard.replicaCount          | Number of dashboard pods                                     | `1`                     |
+| dashboard.image.repository      | Dashboard image repository                                   | `sprints-dashboard`     |
+| dashboard.image.pullPolicy      | Dashboard image pullPolicy                                   | `IfNotPresent`          |
+| dashboard.image.tag             | Dashboard image tag                                          | `local`                 |
+| dashboard.imagePullSecrets      | Dashboard image pull secrets                                 | `[]`                    |
+| dashboard.podSecurityContext    | Dashboard pod security context                               | `{}`                    |
+| dashboard.SecurityContext       | Dashboard container security context                         | `{}`                    |
+| dashboard.service.type          | Dashboard service type                                       | `ClusterIP`             |
+| dashboard.service.annotations   | Dashboard service annotations                                |                         |
+| dashboard.service.port          | Port that the dashboard service is reachable on              | `80`                    |
+| dashboard.service.targetPort    | Port that the dashboard container exposes                    | `8000`                  |
+| dashboard.ingress.enabled       | Whether to enable an ingress resource or not                 | `false`                 |
+| dashboard.ingress.hosts         | if enabled, the default hosts                                | path `/` on `localhost` |
+| dashboard.ingress.tls           | if enabled, the default tls config                           | `[]`                    |
+| dashboard.resources             | Dashboard resource requests and limits                       | `{}`                    |
+| dashboard.nodeSelector          | Dashboard node selector                                      | `{}`                    |
+| dashboard.tolerations           | Dashboard taint tolerations                                  | `[]`                    |
+| dashboard.affinity              | Dashboard pod affinity                                       | `{}`                    |
+| jira.config                     | Jira config file as described [here](#jira-config)           | `{}`                    |
+| jira.credentials.existingSecret | An existing jira secret containing credentials ***required** | `{}`                    |
+| dataCollection.enabled          | Whether to deploy the data collection `Cronjobs` or not      | `false`                 |
+| dataCollection.image.repository | Dashboard image repository                                   | `sprints-dashboard`     |
+| dataCollection.image.pullPolicy | Dashboard image pullPolicy                                   | `IfNotPresent`          |
+| dataCollection.image.tag        | Dashboard image tag                                          | `local`                 |
 
 ## MongoDB Values
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In the case of **mongodb** this helps prevent you from a situation that arises w
 | dashboard.podSecurityContext    | Dashboard pod security context                               | `{}`                                                         |
 | dashboard.SecurityContext       | Dashboard container security context                         | `{}`                                                         |
 | dashboard.service.type          | Dashboard service type                                       | `ClusterIP`                                                  |
-| dashboard.service.annotations   | Dashboard service annotations                                | `service.beta.kubernetes.io/aws-load-balancer-type: externa`l<br />`service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip`<br />`service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing` |
+| dashboard.service.annotations   | Dashboard service annotations                                | `service.beta.kubernetes.io/aws-load-balancer-type: externa`l<br />`service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip`<br />`service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing`<br />`external-dns.alpha.kubernetes.io/hostname: agile-insights-proxy-oauth2-proxy` |
 | dashboard.service.port          | Port that the dashboard service is reachable on              | `80`                                                         |
 | dashboard.service.targetPort    | Port that the dashboard container exposes                    | `8000`                                                       |
 | dashboard.ingress.enabled       | Whether to enable an ingress resource or not                 | `false`                                                      |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ In the case of **mongodb** this helps prevent you from a situation that arises w
 | dashboard.podSecurityContext    | Dashboard pod security context                                         | `{}`                       |
 | dashboard.SecurityContext       | Dashboard container security context                                   | `{}`                       |
 | dashboard.service.type          | Dashboard service type                                                 | `ClusterIP`                |
+| dashboard.service.annotations   | Dashboard service annotations                                          |                            |
 | dashboard.service.port          | Port that the dashboard service is reachable on                        | `80`                       |
 | dashboard.service.targetPort    | Port that the dashboard container exposes                              | `8000`                     |
 | dashboard.ingress.enabled       | Whether to enable an ingress resource or not                           | `false`                    |

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: agile-dashboard
+  annotations: {{ .Values.dashboard.ingress.annotations }}
 spec:
 {{- if .Values.dashboard.ingress.tls }}
   tls:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: agile-dashboard
+  annotations: {{ .Values.dashboard.service.annotations }}
 spec:
   type: {{ .Values.dashboard.service.type }}
   ports:

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,10 @@ dashboard:
   securityContext: {}
   service:
     type: ClusterIP
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: external
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
     port: 80
     targetPort: 8000
   ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -13,11 +13,7 @@ dashboard:
   securityContext: {}
   service:
     type: ClusterIP
-    annotations:
-      service.beta.kubernetes.io/aws-load-balancer-type: external
-      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
-      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-      external-dns.alpha.kubernetes.io/hostname: agile-insights-proxy-oauth2-proxy
+    annotations: []
     port: 80
     targetPort: 8000
   ingress:

--- a/values.yaml
+++ b/values.yaml
@@ -18,6 +18,7 @@ dashboard:
     targetPort: 8000
   ingress:
     enabled: false
+    annotations: []
     hosts:
       - host: localhost
         paths:

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,7 @@ dashboard:
       service.beta.kubernetes.io/aws-load-balancer-type: external
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
       service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+      external-dns.alpha.kubernetes.io/hostname: agile-insights-proxy-oauth2-proxy
     port: 80
     targetPort: 8000
   ingress:


### PR DESCRIPTION
Allow the chart to accept values for `annotations` in the metadata for the kubernetes `service` object.